### PR TITLE
fix resend_code passed to resources

### DIFF
--- a/lib/two_factor_authentication/routes.rb
+++ b/lib/two_factor_authentication/routes.rb
@@ -3,7 +3,7 @@ module ActionDispatch::Routing
     protected
 
       def devise_two_factor_authentication(mapping, controllers)
-        resource :two_factor_authentication, :only => [:show, :update, :resend_code], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
+        resource :two_factor_authentication, :only => [:show, :update], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
           collection { get "resend_code" }
         end
       end


### PR DESCRIPTION
Fix pour la migration à rails 8

`initialize': :only and :except must include only [:show, :create, :update, :destroy, :new, :edit], but also included [:resend_code] (ArgumentError)